### PR TITLE
Minor fixes para a rotina de atualização dos pedidos

### DIFF
--- a/lib/pagseguro-orders-updater.js
+++ b/lib/pagseguro-orders-updater.js
@@ -28,9 +28,14 @@ module.exports = appSdk => {
             const checkOrders = (storeId) => {
               getPagSeguroAuth(storeId)
                 .then(pgAuth => {
-                  const url = 'orders.json?transactions.app.intermediator.code=pagseguro' +
-                    '&sort=-financial_status.updated_at' +
-                    '&fields=transactions,payments_history,financial_status,_id'
+                  const date = new Date()
+                  date.setDate(date.getDate() - 7)
+                  const url = 'orders.json?fields=_id,transactions,payments_history,financial_status' +
+                    '&transactions.app.intermediator.code=pagseguro' +
+                    `&created_at>=${date.toISOString()}` +
+                    '&sort=financial_status.updated_at' +
+                    '&limit=20'
+
                   // pagseguro client
                   const pgsClient = new PagSeguro({
                     appId: process.env.PS_APP_ID,
@@ -121,11 +126,10 @@ module.exports = appSdk => {
   const start = () => task()
     .finally(() => {
       // call again after 12 hours
-      setTimeout(() => start(), 1000 * 60 * 60 * 12)
+      setTimeout(start, 1000 * 60 * 60 * 12)
     })
   // start after 10m
-  setTimeout(() => start(), 10 * 60 * 1000)
-  start()
+  setTimeout(start, 10 * 60 * 1000)
 }
 
 const pgSeguroStatusToEcomplus = code => {


### PR DESCRIPTION
Me parece que o `start` estava sendo chamado duas vezes na inicialização, uma imediatamente e outra 10min depois, aparentemente isto também faria o processo rodar duas vezes a cada 12h (com 10min de intervalo), estou certo @talissonf ?

Limitei os resultados da lista de pedidos a 20, também passei a filtrar pela data de criação a partir de 7 dias atrás e inverti a ordenação (`financial_status.updated_at ASC`), ou seja, vamos buscar até 20 pedidos criados nos últimos 7 dias, começando pelos que foram atualizados a mais tempo (mais desatualizados), faz sentido?